### PR TITLE
Fix to Bank Deposit & Withdrawal errors

### DIFF
--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -501,7 +501,8 @@ function Outfitter:GetSlotIDItemInfo(slotID)
 end
 
 function Outfitter:GetAzeriteCodesForLocation(location)
-	if not C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem(location) then
+	local success,isAzeriteItem  = pcall( function() return C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem(location) end );
+	if not (success and isAzeriteItem) then
 		return
 	end
 


### PR DESCRIPTION
C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem() call inside of Outfitter:GetAzeriteCodesForLocation(location) was throwing an error. Couldn't determine what causes the error, so wrapped the call to C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem() inside of pcall()